### PR TITLE
CustomEvents

### DIFF
--- a/src/App/DomEvents.fs
+++ b/src/App/DomEvents.fs
@@ -10,18 +10,42 @@ open Sutil.DOM
 open Sutil.Attr
 open Sutil.Styling
 open Browser.Types
+open System
+
+let inner() =
+    let r = Random()
+    let clickHandler (e: Event) =
+        let props: CustomDispatch<string> list = [Bubbles true; Detail(Some $"Hello there! %i{r.Next(1000)}")]
+        CustomDispatch.dispatch<string>(e,"on-custom-click", props)
+
+    Html.button [
+        onClick clickHandler []
+        text "I will dispatch a 'on-custom-click' event"
+    ]
 
 let view() =
     Html.div [
         let m = Store.make (0.0,0.0)
+        let m2 = Store.make ""
 
         let handleMousemove (e:MouseEvent) =
             m <~ (e.clientX, e.clientY)
 
-        disposeOnUnmount [m]
+        disposeOnUnmount [m; m2]
 
         onMouseMove handleMousemove []
         Bind.fragment m <| fun (x,y) -> text $"The mouse position is {x} x {y}"
+
+        onCustomEvent<string> "on-custom-click" (fun (e: CustomEvent<string>) -> m2 <~ (e.detail |> Option.defaultValue "")) []
+        Html.div [
+            class' "my-class"
+            Html.p "Custom Events!"
+            inner()
+            Bind.fragment m2 <| fun s -> text $"Got: [{s}]"
+        ] |> withStyle [
+            rule "my-class" [ Css.displayFlex; Css.flexDirectionColumn ]
+        ]
+
     ] |> withStyle [
         rule "div" [
             Css.width (vw 100)

--- a/src/Sutil/Attr.fs
+++ b/src/Sutil/Attr.fs
@@ -43,6 +43,8 @@ let on (event : string) (fn : Event -> unit) (options : EventModifier list) = no
     el.addEventListener(event, h)
     unitResult(ctx, "on")
 
+let onCustomEvent<'T> (event: string) (fn: CustomEvent<'T> -> unit) (options: EventModifier list) =
+    on event (unbox fn) options
 let onKeyboard event (fn : KeyboardEvent -> unit) options =
     on event (unbox fn) options
 

--- a/src/Sutil/Sutil.fsproj
+++ b/src/Sutil/Sutil.fsproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Feliz.Engine" Version="1.0.0-beta-004" />
     <PackageReference Include="Fable.Browser.Css" Version="2.*" />
     <PackageReference Include="Fable.Browser.Dom" Version="2.*" />
+    <PackageReference Include="Fable.Browser.Event" Version="1.*" />
     <PackageReference Include="Fable.Core" Version="3.*" />
     <PackageReference Include="Fable.Promise" Version="2.*" />
     <PackageReference Include="Fable.Browser.MediaQueryList" Version="1.*" />


### PR DESCRIPTION
Here's more-less what I meant with the Custom Event dispatches and generic support to allow for more safe types when using events (particularly custom events)

This is a really really rough implementation and clearly based on what you already did

I'd like to hear about making this a little bit more ergonomic to consume 
I don't think we need too many overloads for the dispatch

```fs
  static member dispatch<'T>( target : EventTarget, name : string, props : CustomDispatch<'T> list ) =
            dispatchCustom<'T> target name (CustomDispatch.toCustomEvent<'T> props)
  static member dispatch<'T>( e : Event, name : string, props : CustomDispatch<'T> list ) =
            dispatchCustom<'T> (e.target) name (CustomDispatch.toCustomEvent<'T> props)
```
I think those should be good enough passing the list of items doesn't seem too bothersome to me but hey I am me

I guess we could also add an overload that takes `detail: 'T` and pass `Bubbles true` (since this one is that makes the magic happen and that's often the case)

Let me know what you think and how can we polish this a little bit more and remove stuff if we don't need to
