### PR TITLE
Properties and Attributes bindings

### DIFF
--- a/Sutil.sln
+++ b/Sutil.sln
@@ -1,19 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31410.357
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{47B70B46-68FB-44A2-88DE-9884B5D1E101}"
 EndProject
-#Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Feliz.Engine", "Feliz.Engine\Feliz.Engine.fsproj", "{024299B9-4DF0-4A75-9EDA-B048F01BD58B}"
-#EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sutil", "src\Sutil\Sutil.fsproj", "{024299B9-4DF0-4A75-9EDA-B048F01BD58A}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Sutil", "src\Sutil\Sutil.fsproj", "{024299B9-4DF0-4A75-9EDA-B048F01BD58A}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "App", "src\App\App.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7073}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "App", "src\App\App.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7073}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "DevTools", "src\DevTools\DevTools.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7074}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "DevTools", "src\DevTools\DevTools.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7074}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Tests", "tests\Tests.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7075}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Tests", "tests\Tests.fsproj", "{21F55368-62BD-477F-9CE7-DAE7828F7075}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{024299B9-4DF0-4A75-9EDA-B048F01BD58A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -52,9 +47,39 @@ Global
 		{21F55368-62BD-477F-9CE7-DAE7828F7073}.Release|x64.Build.0 = Release|Any CPU
 		{21F55368-62BD-477F-9CE7-DAE7828F7073}.Release|x86.ActiveCfg = Release|Any CPU
 		{21F55368-62BD-477F-9CE7-DAE7828F7073}.Release|x86.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|x64.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Debug|x86.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|x64.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|x64.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|x86.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7074}.Release|x86.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|x64.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Debug|x86.Build.0 = Debug|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|x64.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|x64.Build.0 = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|x86.ActiveCfg = Release|Any CPU
+		{21F55368-62BD-477F-9CE7-DAE7828F7075}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{024299B9-4DF0-4A75-9EDA-B048F01BD58A} = {47B70B46-68FB-44A2-88DE-9884B5D1E101}
 		{21F55368-62BD-477F-9CE7-DAE7828F7073} = {47B70B46-68FB-44A2-88DE-9884B5D1E101}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DE9E3043-9AE3-41E0-98CD-B6104C44E749}
 	EndGlobalSection
 EndGlobal

--- a/src/App/App.fs
+++ b/src/App/App.fs
@@ -83,6 +83,7 @@ let allExamples = [
         { Category = "Bindings";   Title = "Select bindings";  Create = SelectBindings.view ; Sections = ["SelectBindings.fs"]}
         { Category = "Bindings";   Title = "Select multiple";  Create = SelectMultiple.view ; Sections = ["SelectMultiple.fs"]}
         { Category = "Bindings";   Title = "Dimensions";  Create = Dimensions.view ; Sections = ["Dimensions.fs"]}
+        { Category = "Bindings";   Title = "Attributes and Properties";  Create = AttributesAndProperties.view ; Sections = ["AttributesAndProperties.fs"]}
         { Category = "Svg";   Title = "Bar chart";  Create = BarChart.view ; Sections = ["BarChart.fs"]}
         { Category = "Miscellaneous";   Title = "Spreadsheet";  Create = Spreadsheet.view ; Sections = ["Spreadsheet.fs"; "Evaluator.fs"; "Parser.fs"]}
         { Category = "Miscellaneous";   Title = "Modal";  Create = Modal.view ; Sections = ["Modal.fs"]}

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="StaticEach.fs" />
     <Compile Include="StaticEachWithIndex.fs" />
     <Compile Include="Dimensions.fs" />
+    <Compile Include="AttributesAndProperties.fs" />
     <Compile Include="FileInputs.fs" />
     <Compile Include="LogicIf.fs" />
     <Compile Include="LogicElse.fs" />

--- a/src/App/AttributesAndProperties.fs
+++ b/src/App/AttributesAndProperties.fs
@@ -1,0 +1,53 @@
+﻿module AttributesAndProperties
+
+open type Feliz.length
+open Sutil
+open Sutil.Attr
+open Sutil.DOM
+open Sutil.Styling
+
+
+let view() =
+    let bindToAttribute = Store.make "Some Value"
+    let bindToProperty = Store.make false
+
+    Html.div [
+        Html.p [
+            text """You can bind properties and attributes by using the `Bind` API. The Bind API provides with helpers to bind either attributes or properties.
+            Sometimes developers may wrongly believe that Attributes and Properties are the same but HTML Elements have both
+            and they don't necesarily match each other. Attributes are commonly refered in an HTML as 
+            """
+            Html.pre "<my-element this-is-an-attribute=\"and this is the value\"></my-element>"
+            text "where as properties are attached to an HTML element instance like"
+            Html.pre "documment.querySelector(\"#my-element\").myProperty"
+            text "and these can be read or assigned to see how this example works you should open the browser developer tools and inspect this text"
+            text "Example: "
+            Html.br []
+            Html.br []
+            Bind.attr("data-my-attr", bindToAttribute)
+            bindFragment bindToAttribute <| fun value ->
+                text value
+        ]
+
+        Html.input [
+            type' "checkbox"
+            Bind.prop(
+                "checked",
+                bindToProperty,
+                fun chkd -> 
+                    if chkd then 
+                        bindToAttribute <~ "I'm checked, inspect my attributes"
+                    else 
+                        bindToAttribute <~ "I'm not checked, inspect my attributes"
+            )
+        ]
+
+        Html.p [
+            text "In this case, we're binding the \"data-my-attr\" to the \"p\" tag above to a string store which in turn is "
+            text "modified by the checkbox, we're also, binding the checkbox's checked property and adding a handler "
+            text "That will update the string store each time it changes."
+            Html.br []
+            text "While there are many custom elements and HTML elements that might match the attribute name "
+            text "to an element property not it is not always the case, so be sure to read your library's documentation."
+        ]
+    ]

--- a/src/App/Dimensions.fs
+++ b/src/App/Dimensions.fs
@@ -33,11 +33,11 @@ let view() =
 
         Html.div [
             class' "block"
-            Html.input [ type' "range"; Bind.attr("value",size) ]
+            Html.input [ type' "range"; Bind.prop("value",size) ]
         ]
         Html.div [
             class' "block"
-            Html.input [ type' "text"; Bind.attr("value",text) ]
+            Html.input [ type' "text"; Bind.prop("value",text) ]
         ]
 
         Html.div [
@@ -46,10 +46,10 @@ let view() =
 
         Html.div [
             class' "resizing"
-            bindPropOut "clientWidth" w
-            bindPropOut "clientHeight" h
+            bindPropStoreOut "clientWidth" w
+            bindPropStoreOut "clientHeight" h
             Html.span [
-                Bind.attr( "style", size |> Store.map (fun n -> $"font-size: {n}px") )
+                Bind.attr("style", size |> Store.map (fun n -> $"font-size: {n}px") )
                 Bind.fragment text DOM.text
             ]
         ]

--- a/src/App/Login.fs
+++ b/src/App/Login.fs
@@ -112,7 +112,7 @@ let private defaultView model dispatch =
                             bulma.field.div [
                                 bulma.inputLabels.checkbox [
                                     bulma.input.checkbox [
-                                        Bind.attr("checked", model .> rememberMe, SetRememberMe >> dispatch)
+                                        Bind.prop("checked", model .> rememberMe, SetRememberMe >> dispatch)
                                     ]
                                     Html.text " Remember me"
                                 ]
@@ -145,7 +145,9 @@ let private createWithView initDetails login cancel view =
             |SetUsername name -> { model with Details = { model.Details with Username = name }}, Cmd.none
             |SetPassword pwd -> { model with Details = { model.Details with Password = pwd}}, Cmd.none
             |SetRememberMe z -> { model with Details = { model.Details with RememberMe = z }}, Cmd.none
-            |AttemptLogin -> model, Cmd.OfFunc.attempt login model.Details (fun ex -> SetMessage ex.Message)
+            |AttemptLogin ->
+                printfn "%A" model
+                model, Cmd.OfFunc.attempt login model.Details (fun ex -> SetMessage ex.Message)
             |SetMessage m -> { model with Message = m }, Cmd.none
             |CancelLogin -> model, Cmd.OfFunc.perform cancel () (fun _ -> SetMessage "")
 

--- a/src/App/LoginExample.fs
+++ b/src/App/LoginExample.fs
@@ -81,7 +81,7 @@ let create() =
                         | Some u ->
                             Html.span [
                                 text u.Name
-                                text " "
+                                text $"%A{u} "
                                 Html.a [
                                     text "sign out"
                                     Attr.href "#"

--- a/src/Sutil/Bindings.fs
+++ b/src/Sutil/Bindings.fs
@@ -150,6 +150,9 @@ let private getInputChecked el = Interop.get el "checked"
 let private setInputChecked (el : Node) (v:obj) = Interop.set el "checked" v
 let private getInputValue el : string = Interop.get el "value"
 let private setInputValue el (v:string) = Interop.set el "value" v
+let private setAttribute (el: Node) (attribute: string) (value: obj) = 
+    let el = el :?> HTMLElement
+    el.setAttribute(attribute, string value)
 
 let bindSelected<'T when 'T : equality> (selection:IObservable<List<'T>>) (dispatch : List<'T> -> unit) : SutilElement = nodeFactory <| fun ctx ->
 
@@ -273,55 +276,98 @@ let bindAttrIn<'T> (attrName:string) (store : IObservable<'T>) : SutilElement = 
         if attrName = "class" then
             store |> Store.subscribe (fun cls -> ctx.ParentElement.className <- (string cls))
         else
-            store |> Store.subscribe (DOM.setAttribute ctx.ParentElement attrName)
+            store |> Store.subscribe (setAttribute ctx.ParentElement attrName)
     SutilNode.RegisterDisposable(ctx.Parent,unsub)
     unitResult(ctx,"bindAttrIn")
 
-let bindAttrOut<'T> (attrName:string) (onchange : 'T -> unit) : SutilElement = nodeFactory <| fun ctx ->
-    let parent = ctx.ParentNode
+// Bind a store value to an element property. Updates to the element are unhandled
+let bindPropIn<'T> (propName:string) (store : IObservable<'T>) : SutilElement = nodeFactory <| fun ctx ->
+    let unsub =
+        store |> Store.subscribe (Interop.set ctx.ParentElement propName)
+    SutilNode.RegisterDisposable(ctx.Parent,unsub)
+    unitResult(ctx,"bindPropIn")
+
+let bindAttrOut<'T> (attrName:string) (onchange : string -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
     let unsubInput = listen "input" parent <| fun _ ->
-        Interop.get parent attrName |> onchange
+        parent.getAttribute(attrName) |> onchange
     SutilNode.RegisterUnsubscribe(ctx.Parent,unsubInput)
     unitResult(ctx,"bindAttrOut")
+
+let bindPropOut<'T> (propName:string) (onchange : 'T -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode
+    let unsubInput = listen "input" parent <| fun _ ->
+        Interop.get parent propName |> onchange
+    SutilNode.RegisterUnsubscribe(ctx.Parent,unsubInput)
+    unitResult(ctx,"bindPropOut")
 
 // Bind a scalar value to an element attribute. Listen for onchange events and dispatch the
 // attribute's current value to the given function. This form is useful for view templates
 // where v is invariant (for example, an each that already filters on the value of v, like Todo.Done)
-let attrNotify<'T> (attrName:string) (value :'T) (onchange : 'T -> unit) : SutilElement = nodeFactory <| fun ctx ->
-    let parent = ctx.ParentNode
+let attrNotify<'T> (attrName:string) (value :'T) (onchange : string -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
     let unsubInput = listen "input" parent  <| fun _ ->
-        Interop.get parent attrName |> onchange
-    Interop.set parent attrName value
+        parent.getAttribute(attrName) |> onchange
+    setAttribute parent attrName value
     SutilNode.RegisterUnsubscribe(ctx.Parent,unsubInput)
     unitResult(ctx,"attrNotify")
 
-// Bind an observable value to an element attribute. Listen for onchange events and dispatch the
+// Bind a scalar value to an element property. Listen for onchange events and dispatch the
+// attribute's current value to the given function. This form is useful for view templates
+// where v is invariant (for example, an each that already filters on the value of v, like Todo.Done)
+let propNotify<'T> (propName:string) (value :'T) (onchange : 'T -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
+    let unsubInput = listen "input" parent  <| fun _ ->
+        Interop.get parent propName |> onchange
+    Interop.set parent propName value
+    SutilNode.RegisterUnsubscribe(ctx.Parent,unsubInput)
+    unitResult(ctx,"attrNotify")
+
+// Bind an observable value to an element property. Listen for onchange events and dispatch the
 // attribute's current value to the given function
-let bindAttrBoth<'T> (attrName:string) (value : IObservable<'T>) (onchange : 'T -> unit) : SutilElement =
+let bindPropBoth<'T> (attrName:string) (value : IObservable<'T>) (onchange : 'T -> unit) : SutilElement =
     fragment [
-        bindAttrIn attrName value
-        bindAttrOut attrName onchange
+        bindPropIn attrName value
+        bindPropOut attrName onchange
     ]
 
-let bindListen<'T> (attrName:string) (store : IObservable<'T>) (event:string) (handler : Event -> unit) : SutilElement = nodeFactory <| fun ctx ->
-    let parent = ctx.ParentNode
+let bindAttrListen<'T> (attrName:string) (store : IObservable<'T>) (event:string) (handler : Event -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
     let unsubA = Sutil.DOM.listen event parent handler
-    let unsubB = store |> Store.subscribe ( Interop.set parent attrName )
+    let unsubB = store |> Store.subscribe (setAttribute parent attrName)
     SutilNode.RegisterUnsubscribe(ctx.Parent,unsubA)
     SutilNode.RegisterDisposable(ctx.Parent,unsubB)
-    unitResult(ctx,"bindListen")
+    unitResult(ctx,"bindAttrListen")
+
+let bindPropListen<'T> (attrName:string) (store : IObservable<'T>) (event:string) (handler : Event -> unit) : SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
+    let unsubA = Sutil.DOM.listen event parent handler
+    let unsubB = store |> Store.subscribe (Interop.set parent attrName)
+    SutilNode.RegisterUnsubscribe(ctx.Parent,unsubA)
+    SutilNode.RegisterDisposable(ctx.Parent,unsubB)
+    unitResult(ctx,"bindPropListen")
 
 // Bind a store value to an element attribute. Listen for onchange events write the converted
 // value back to the store
 let private bindAttrConvert<'T> (attrName:string) (store : Store<'T>) (convert : obj -> 'T) : SutilElement = nodeFactory <| fun ctx ->
-    let parent = ctx.ParentNode
+    let parent = ctx.ParentNode :?> HTMLElement
     //let attrName' = if attrName = "value" then "__value" else attrName
     let unsubInput = DOM.listen "input" parent <| fun _ ->
-        Interop.get parent attrName |> convert |> Store.set store
-    let unsub = store |> Store.subscribe ( Interop.set parent attrName )
+        parent.getAttribute(attrName) |> convert |> Store.set store
+    let unsub = store |> Store.subscribe ( setAttribute parent attrName )
     SutilNode.RegisterUnsubscribe(parent,unsubInput)
     SutilNode.RegisterDisposable(parent,unsub)
     unitResult(ctx,"bindAttrConvert")
+
+let private bindPropConvert<'T> (propName: string) (store: Store<'T>) (convert: obj -> 'T): SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode
+    //let attrName' = if attrName = "value" then "__value" else attrName
+    let unsubInput = DOM.listen "input" parent <| fun _ ->
+        Interop.get parent propName |> convert |> Store.set store
+    let unsub = store |> Store.subscribe ( Interop.set parent propName )
+    SutilNode.RegisterUnsubscribe(parent,unsubInput)
+    SutilNode.RegisterDisposable(parent,unsub)
+    unitResult(ctx,"bindPropConvert")
 
 // Unsure how to safely convert Element.getAttribute():string to 'T
 let private convertObj<'T> (v:obj) : 'T  =
@@ -331,7 +377,10 @@ let private convertObj<'T> (v:obj) : 'T  =
 let bindAttrStoreBoth<'T> (attrName:string) (store : Store<'T>) =
     bindAttrConvert attrName store convertObj<'T>
 
-let bindAttrStoreOut<'T> (attrName:string) (store : Store<'T>) : SutilElement = nodeFactory <| fun ctx ->
+let bindPropStoreBoth<'T> (propName: string) (store: Store<'T>) =
+    bindPropConvert propName store convertObj<'T>
+
+let bindPropStoreOut<'T> (attrName:string) (store : Store<'T>) : SutilElement = nodeFactory <| fun ctx ->
     let parent = ctx.ParentNode
     let unsubInput = DOM.listen "input" parent <| fun _ ->
         Interop.get parent attrName |> convertObj<'T> |> Store.set store
@@ -342,6 +391,20 @@ let bindAttrStoreOut<'T> (attrName:string) (store : Store<'T>) : SutilElement = 
 let private attrIsSizeRelated  (attrName:string) =
     let upr = attrName.ToUpper()
     upr.IndexOf("WIDTH") >= 0 || upr.IndexOf("HEIGHT") >= 0
+
+let listenToAttr<'T> (attrName: string) (dispatch: 'T -> unit): SutilElement = nodeFactory <| fun ctx ->
+    let parent = ctx.ParentNode :?> HTMLElement
+    let notify() = parent.getAttribute(attrName) |> convertObj<'T> |> dispatch
+
+    once Event.ElementReady parent <| fun _ ->
+        if attrIsSizeRelated attrName then
+            SutilNode.RegisterDisposable(parent,(ResizeObserver.getResizer (downcast parent)).Subscribe( notify ))
+        else
+            SutilNode.RegisterUnsubscribe(parent,DOM.listen "input" parent (fun _ -> notify()))
+
+        rafu notify
+
+    unitResult(ctx,"listenToProp")
 
 let listenToProp<'T> (attrName:string) (dispatch: 'T -> unit) : SutilElement = nodeFactory <| fun ctx ->
     let parent = ctx.ParentNode
@@ -357,8 +420,6 @@ let listenToProp<'T> (attrName:string) (dispatch: 'T -> unit) : SutilElement = n
 
     unitResult(ctx,"listenToProp")
 
-let bindPropOut<'T> (attrName:string) (store : Store<'T>) : SutilElement =
-    listenToProp attrName (Store.set store)
 
 type KeyedStoreItem<'T,'K> = {
     Key : 'K
@@ -584,18 +645,30 @@ module BindApi =
         /// an IObservable, for which a separate overload exists.
         static member attr<'T> (name:string, value: IStore<'T>) = bindAttrStoreBoth name value
 
+        /// Dual-binding for a given property. Changes to value are written to the property, while
+        /// changes to the property are written back to the store. Note that an IStore is also
+        /// an IObservable, for which a separate overload exists.
+        static member prop<'T> (name:string, value: IStore<'T>) = bindPropStoreBoth name value
+
         /// One-way binding from value to attribute. Note that passing store to this function will
         /// select the more specific `attr<'T>( string, IStore<'T>)` overload.
         /// If that looks to be a problem, we'll rename both of them to force a considered choice.
         static member attr<'T> (name:string, value: IObservable<'T>) = bindAttrIn name value
 
+        /// One-way binding from value to property. Note that passing store to this function will
+        /// select the more specific `prop<'T>( string, IStore<'T>)` overload.
+        /// If that looks to be a problem, we'll rename both of them to force a considered choice.
+        static member prop<'T> (name:string, value: IObservable<'T>) = bindPropIn name value
+
         /// One-way binding from attribute to dispatch function
-        static member attr<'T> (name:string, dispatch: 'T -> unit) = bindAttrOut name dispatch
+        static member attr<'T> (name:string, dispatch: string -> unit) = listenToAttr name dispatch
 
-        /// Two-way binding from value to attribute and from attribute to dispatch function
-        static member attr<'T> (name:string, value: IObservable<'T>, dispatch: 'T -> unit) =
-            bindAttrBoth name value dispatch
+        /// One-way binding from property to dispatch function
+        static member prop<'T> (name:string, dispatch: 'T -> unit) = listenToProp name dispatch
 
+        /// Two-way binding from value to property and from property to dispatch function
+        static member prop<'T> (name:string, value: IObservable<'T>, dispatch: 'T -> unit) =
+            bindPropBoth name value dispatch
 
         /// Binding from value to a DOM fragment. Each change in value replaces the current DOM fragment
         /// with a new one.

--- a/src/Sutil/DOM.fs
+++ b/src/Sutil/DOM.fs
@@ -1204,7 +1204,7 @@ let setAttribute (el:HTMLElement) (name:string) (value:obj) =
     //if (name = "value") then
     //    Interop.set el "__value" value // Un-stringified version of value
 
-let attr (name,value:obj) : SutilElement = nodeFactory <| fun ctx ->
+let attr (name, value:obj) : SutilElement = nodeFactory <| fun ctx ->
     let parent = ctx.Parent.AsDomNode
     try
         let e = parent :?> HTMLElement

--- a/src/Sutil/Html.fs
+++ b/src/Sutil/Html.fs
@@ -38,7 +38,7 @@ type SutilAttrEngine() =
 
     member _.value<'T> (value: IObservable<'T>) = bindAttrIn "value" value
     member _.value<'T> (value: IObservable<'T>, dispatch: 'T -> unit) =
-            bindAttrBoth "value" value dispatch
+            bindPropBoth "value" value dispatch
 
     member _.style (cssAttrs : (string*obj) seq) = cssAttrs |> Sutil.Attr.style
 


### PR DESCRIPTION
This PR addresses (or at least tries to #33 
there's only one backwards incompatible change which is that you can't two-way bind to an attribute anymore since that would require adding a deserialization from string but the same case is covered by a property binding (which is the how the previous bindings worked)

cc @davedawkins 