### PR TITLE
IReadOnlyStore and VirtualStore

### DIFF
--- a/src/Sutil/Types.fs
+++ b/src/Sutil/Types.fs
@@ -52,16 +52,32 @@ module DevToolsControl =
 
 type Unsubscribe = unit -> unit
 
-type IStore<'T> =
+type IReadOnlyStore<'T> =
     interface
         inherit IObservable<'T>
         inherit IDisposable
-        abstract Update : f: ('T -> 'T) -> unit
         abstract Value : 'T
         abstract Debugger : IStoreDebugger
     end
 
+type IStore<'T> =
+    interface
+        inherit IReadOnlyStore<'T>
+        abstract Update : f: ('T -> 'T) -> unit
+        // abstract Name : string with get, set
+    end
+
+type IVirtualStore<'T> =
+    interface
+        inherit IStore<'T>
+        abstract member UpdateCallback: ('T -> unit)
+    end
+
 type Store<'T> = IStore<'T>
+
+type ReadOnlyStore<'T> = IReadOnlyStore<'T>
+
+type VirtualStore<'T> = IVirtualStore<'T>
 
 type Update<'Model> = ('Model -> 'Model) -> unit // A store updater. Store updates by being passed a model updater
 


### PR DESCRIPTION
I am not sure about this one.  Is this duplicating functionality?

One semantic issue I see is that when you write to a `VirtualStore`, there's no guarantee that the value will ever change.

That causes some issue when binding a `VirtualStore` to a set of radio buttons:
 If the virtual store rejects the write message, the UI will not reflect it.
A solution might be to trigger a fake notification event before the dispatch function is called, but that would create even more complex interaction with `Store.distinct`.

I'm still experimenting and growing my test app, so I'll probably revisit this PR later on.

[Example usage of `VirtualStore`](https://github.com/PierreYvesR/WldMr.Sutil.Demo/search?q=VirtualStore)
[Where `ReadOnlyStore` would be useful](https://github.com/PierreYvesR/WldMr.Sutil.Demo/search?q=ReadOnlyStore)
