### PR TITLE
Enable SourceLink

### DIFF
--- a/src/Sutil/Sutil.fsproj
+++ b/src/Sutil/Sutil.fsproj
@@ -16,6 +16,11 @@
     <UsesMarkdownComments>false</UsesMarkdownComments>
     <DefineConstants>$(DefineConstants);FABLE_COMPILER;</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Easing.fs" />
     <Compile Include="Interop.fs" />
@@ -46,6 +51,7 @@
     <Compile Include="Bulma.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="ConstructStyleSheetsPolyfill" Version="1.0.0-beta-001" />
     <PackageReference Include="Feliz.Engine.Bulma" Version="1.0.0-*" />
     <PackageReference Include="Feliz.Engine" Version="1.0.0-beta-004" />


### PR DESCRIPTION
This PR enable SourceLink support for the Sutil project.
This helps as I can go to definition on any symbol inside my IDE (Rider) and see the code definition.