### PR TITLE
Added Observable.map2 and Store.map2 functions

### DIFF
--- a/src/Sutil/Store.fs
+++ b/src/Sutil/Store.fs
@@ -91,6 +91,21 @@ module Store =
     let map<'A, 'B> (callback: 'A -> 'B) (store: IObservable<'A>) = store |> Observable.map callback
 
     /// <summary>
+    /// Returns an observable that will resolve to the result of said callback applied to two observables
+    /// </summary>
+    /// <example>
+    /// <code>
+    ///     let subscription: IObservable&lt;int&gt; =
+    ///         Store.map2 (fun value1 value2 -> value1 * value2) intStore1 intStore2
+    ///
+    ///     (* after you are done with the subscription *)
+    ///
+    ///     subscription.Dispose()
+    /// </code>
+    /// </example>
+    let map2<'A, 'B, 'Res> (callback: 'A -> 'B -> 'Res) (storeA: IObservable<'A>) (storeB: IObservable<'B>) = Observable.map2<'A, 'B, 'Res> callback storeA storeB
+
+    /// <summary>
     /// Applies a predicate function to obtain an observable of the elements that evaluated to true
     /// </summary>
     /// <example>

--- a/tests/test/ObservableTest.fs
+++ b/tests/test/ObservableTest.fs
@@ -47,6 +47,28 @@ describe "Sutil.Observable" <| fun () ->
         Expect.areEqual(3,n2) // - a b
     }
 
+    it "map2" <| fun () -> promise {
+        let s1 = Store.make 3
+        let s2 = Store.make 5
+
+        let mutable result = 0
+        let mapped = (s1, s2) ||> Observable.map2 (fun s1 s2 -> s1 * s2)
+        use _ = Store.subscribe (fun x -> result <- x) mapped
+
+        Expect.areEqual(15, result)
+    }
+
+    it "zip" <| fun () -> promise {
+        let s1 = Store.make 3
+        let s2 = Store.make 5
+
+        let mutable result = (0,0)
+        let mapped = (s1, s2) ||> Observable.zip
+        use _ = Store.subscribe (fun x -> result <- x) mapped
+
+        Expect.areEqual((3,5), result)
+    }
+
     //it "exists" <| fun () ->
     //    let s1 = Store.make '-'
     //    let s2 =


### PR DESCRIPTION
Hi,

As discussed ages ago on Slack, here's a PR for Store.map2 and Observable.map2. I was able to test this after modifying the .sln to include Fable.Expect project and updated npm packages for test-runner (these changes are not included in this PR). 

Since zip is just a generalization of map2, I took the liberty of using the latter to implement it.