### PR TITLE
feat: Observable.once — subscribe and unsubscribe after first event

### DIFF
--- a/src/Sutil/Observable.fs
+++ b/src/Sutil/Observable.fs
@@ -248,6 +248,20 @@ module Observable =
                 Helpers.disposable (fun _ -> disposeA.Dispose() )
         }
 
+
+    // Unsubscribe after first event
+    let once (cb : 'T -> unit) (source : IObservable<'T>) =
+        let mutable disposeA = ignore
+        
+        disposeA <- source.Subscribe( fun x ->
+            cb x
+            disposeA()
+            disposeA <- ignore
+        ) |> fun d -> fun () -> d.Dispose()
+        
+        Helpers.disposable (fun _ -> disposeA() )
+
+
     let wait (waitService : (unit -> unit) -> unit) (source : IObservable<'T>) =
         { new System.IObservable<'T> with
             member _.Subscribe( h : IObserver<'T> ) =


### PR DESCRIPTION
## Summary

New combinator that subscribes to an observable, invokes the callback on the first event, and immediately disposes the subscription. Returns an IDisposable so callers can cancel before the first event fires.

Used by fsimgo to wire one-shot page-activation handlers (see davedawkins/fsimgo#224 → DisplayControl `nodeViewDiv` container init). The nested Subscribe + dispose-self pattern this captures is obvious-but-fiddly to write by hand.

## Test plan

- [ ] Build clean (`dotnet build src/Sutil`).
- [ ] fsimgo's `npm run dev` compiles against this branch (consumes `Observable.once`).
- [ ] Subscription disposed exactly once on first event; further events ignored; pre-event dispose cancels without firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)